### PR TITLE
SELinux state should now be correctly set back to `enforcing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.2 (Unreleased)
+
+BUG FIXES:
+
+Fix issue whereas SELinux state would not be correctly set back to `enforcing` when `nginx_unit_selinux: true`.
+
 ## 0.2.1 (November 19, 2020)
 
 ENHANCEMENTS:

--- a/tasks/prerequisites/setup-selinux.yml
+++ b/tasks/prerequisites/setup-selinux.yml
@@ -21,8 +21,6 @@
   selinux:
     state: permissive
     policy: targeted
-  changed_when: false
-  when: ansible_facts['selinux']['mode'] == "enforcing"
 
 - name: Allow SELinux HTTP network connections
   seboolean:
@@ -56,7 +54,4 @@
   selinux:
     state: enforcing
     policy: targeted
-  changed_when: false
-  when:
-    - nginx_unit_selinux_enforcing | bool
-    - ansible_facts['selinux']['mode'] == "permissive"
+  when: nginx_unit_selinux_enforcing | bool


### PR DESCRIPTION
### Proposed changes
Fix issue whereas SELinux state would not be correctly set back to `enforcing` when `nginx_unit_selinux: true`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

-   [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/ansible-role-nginx-unit/blob/main/CONTRIBUTING.md) document
-   [x] I have added Molecule tests that prove my fix is effective or that my feature works
-   [x] I have checked that all Molecule tests pass after adding my changes
-   [x] I have updated any relevant documentation (`defaults/main/*.yml`, `README.md` and `CHANGELOG.md`)
